### PR TITLE
HOTFIX: Remove maven symlink causing Vercel build error

### DIFF
--- a/maven
+++ b/maven
@@ -1,1 +1,0 @@
-apache-maven-3.6.0./


### PR DESCRIPTION
Fixes Vercel deployment error:


The maven symlink was accidentally committed and is causing Vercel builds to fail. This removes it to restore deployments.

**Critical:** This needs to be merged immediately to restore app functionality.